### PR TITLE
Support type hints

### DIFF
--- a/pydictable/type.py
+++ b/pydictable/type.py
@@ -1,0 +1,32 @@
+from abc import abstractmethod
+
+
+class Field:
+    def __init__(self, required: bool = False, key: str = None):
+        self.required = required
+        self.key = key
+
+    @abstractmethod
+    def from_dict(self, v):
+        pass
+
+    @abstractmethod
+    def to_dict(self, v):
+        pass
+
+    @abstractmethod
+    def validate_dict(self, field_name: str, v):
+        pass
+
+    @abstractmethod
+    def validate(self, field_name: str, v):
+        pass
+
+
+class _BaseDictAble:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def to_dict(self) -> dict:
+        pass

--- a/pydictable/type.py
+++ b/pydictable/type.py
@@ -22,6 +22,9 @@ class Field:
     def validate(self, field_name: str, v):
         pass
 
+    def of_type(self):
+        return
+
 
 class _BaseDictAble:
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Support native python type hints
- Type hints - int, str, float, bool, list, union, optional
- Data validation path - Ex: user.avatar.size.gaps.[3] is not a number
- Detailed input spec