### PR TITLE
Handle multiple fields with the same type in union

### DIFF
--- a/pydictable/field.py
+++ b/pydictable/field.py
@@ -225,46 +225,46 @@ class DictValueField(Field):
 class UnionField(Field):
     def __init__(self, fields: List[Field], *args, **kwargs):
         super(UnionField, self).__init__(*args, **kwargs)
-        self.fields_list = [{'name': f.__class__.__name__, 'field': f} for f in fields]
+        self.fields = fields
 
     def from_dict(self, v):
-        for fd in self.fields_list:
+        for field in self.fields:
             try:
-                fd['field'].validate_dict('', v)
-                return fd['field'].from_dict(v)
+                field.validate_dict('', v)
+                return field.from_dict(v)
             except (AssertionError, DataValidationError):
                 pass
         raise NotImplementedError()
 
     def to_dict(self, v, skip_optional: bool = False):
-        for fd in self.fields_list:
+        for field in self.fields:
             try:
-                fd['field'].validate('', v)
-                return fd['field'].to_dict(v, skip_optional)
+                field.validate('', v)
+                return field.to_dict(v, skip_optional)
             except AssertionError:
                 pass
         raise NotImplementedError()
 
     def validate_dict(self, field_name: str, v):
-        for fd in self.fields_list:
+        for field in self.fields:
             try:
-                fd['field'].validate_dict('', v)
+                field.validate_dict('', v)
                 return
             except (AssertionError, DataValidationError):
                 pass
-        raise AssertionError(f'{v} does not match for any of {[fd["name"] for fd in self.fields_list]}')
+        raise AssertionError(f'{v} does not match for any of {[f.__class__.__name__ for f in self.fields]}')
 
     def validate(self, field_name: str, v):
-        for fd in self.fields_list:
+        for field in self.fields:
             try:
-                fd['field'].validate('', v)
+                field.validate('', v)
                 return
             except (AssertionError, DataValidationError) as e:
                 pass
-        raise AssertionError(f'{v} does not match for any of {[fd["name"] for fd in self.fields_list]}')
+        raise AssertionError(f'{v} does not match for any of {[f.__class__.__name__ for f in self.fields]}')
 
     def of(self):
-        return [fd['field'].spec() for fd in self.fields_list]
+        return [field.spec() for field in self.fields]
 
 
 class NoneField(Field):

--- a/pydictable/field.py
+++ b/pydictable/field.py
@@ -264,7 +264,7 @@ class UnionField(Field):
         raise AssertionError(f'{v} does not match for any of {[f.__class__.__name__ for f in self.fields]}')
 
     def of(self):
-        return [field.spec() for field in self.fields]
+        return [f.spec() for f in self.fields]
 
 
 class NoneField(Field):

--- a/pydictable/field.py
+++ b/pydictable/field.py
@@ -259,7 +259,7 @@ class UnionField(Field):
             try:
                 field.validate('', v)
                 return
-            except (AssertionError, DataValidationError) as e:
+            except AssertionError:
                 pass
         raise AssertionError(f'{v} does not match for any of {[f.__class__.__name__ for f in self.fields]}')
 

--- a/pydictable/test_core.py
+++ b/pydictable/test_core.py
@@ -366,6 +366,27 @@ class TestCore(TestCase):
         self.assertEqual(User(roll_no="1").roll_no, "1")
         self.assertEqual(User(roll_no=1).roll_no, 1)
 
+    def test_union_field_with_same_field_types(self):
+        class Item1(DictAble):
+            area: int = IntField(required=True)
+
+        class Item2(DictAble):
+            volume: int = IntField(required=True)
+
+        class Receipt(DictAble):
+            items: list[Union[Item1, Item2]] = ListField(
+                UnionField([ObjectField(Item1), ObjectField(Item2)], required=True), required=True)
+
+        data = {'items': [{'area': 10}, {'volume': 100}]}
+        rec = Receipt(dict=data)
+        self.assertIsInstance(rec.items[0], Item1)
+        self.assertEqual(rec.items[0].area, 10)
+        self.assertIsInstance(rec.items[1], Item2)
+        self.assertEqual(rec.items[1].volume, 100)
+
+        data = {'items': [{'area': 10}, {'foo': 100}]}
+        self.assertRaises(DataValidationError, lambda: Receipt(dict=data))
+
     def test_type_hints(self):
         class Address(DictAble):
             pin: Optional[str]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='pydictable',
-    version='2.0.1',
+    version='2.0.2',
     author='Pramod Kumar',
     author_email='pramodkumar.damam73@gmail.com',
     description='Make your classes from/to dict',


### PR DESCRIPTION
Union field was maintaining a dictionary with `{field_type: field_instance}` mapping, hence overriding fields with the same type